### PR TITLE
ConflictDetection_NO_PERMISSION OOTB method incorrect template

### DIFF
--- a/Aras.VS.MethodPlugin.11sp10CSharp/method-config.xml
+++ b/Aras.VS.MethodPlugin.11sp10CSharp/method-config.xml
@@ -599,7 +599,7 @@ End Namespace
 ]]>
   </Template>
 
-  <Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19">
+  <Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
     <![CDATA[
 using System;
 using System.IO;
@@ -693,7 +693,7 @@ namespace $(pkgname)
 }
 ]]>
   </Template>
-  <Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19">
+  <Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
     <![CDATA[
 using System;
 using System.IO;

--- a/Aras.VS.MethodPlugin.11sp11CSharp/method-config.xml
+++ b/Aras.VS.MethodPlugin.11sp11CSharp/method-config.xml
@@ -599,7 +599,7 @@ End Namespace
 ]]>
   </Template>
 
-  <Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19">
+  <Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
     <![CDATA[
 using System;
 using System.IO;
@@ -693,7 +693,7 @@ namespace $(pkgname)
 }
 ]]>
   </Template>
-  <Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19">
+  <Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
     <![CDATA[
 using System;
 using System.IO;

--- a/Aras.VS.MethodPlugin.11sp12CSharp/method-config.xml
+++ b/Aras.VS.MethodPlugin.11sp12CSharp/method-config.xml
@@ -600,7 +600,7 @@ End Namespace
 ]]>
 	</Template>
 
-	<Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19">
+	<Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
 		<![CDATA[
 using System;
 using System.IO;
@@ -694,7 +694,7 @@ namespace $(pkgname)
 }
 ]]>
 	</Template>
-	<Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19">
+	<Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
 		<![CDATA[
 using System;
 using System.IO;

--- a/Aras.VS.MethodPlugin.11sp14CSharp/method-config.xml
+++ b/Aras.VS.MethodPlugin.11sp14CSharp/method-config.xml
@@ -600,7 +600,7 @@ End Namespace
 ]]>
 	</Template>
 
-	<Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19">
+	<Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
 		<![CDATA[
 using System;
 using System.IO;
@@ -694,7 +694,7 @@ namespace $(pkgname)
 }
 ]]>
 	</Template>
-	<Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19">
+	<Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
 		<![CDATA[
 using System;
 using System.IO;

--- a/Aras.VS.MethodPlugin.11sp15CSharp/method-config.xml
+++ b/Aras.VS.MethodPlugin.11sp15CSharp/method-config.xml
@@ -600,7 +600,7 @@ End Namespace
 ]]>
 	</Template>
 
-	<Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19">
+	<Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
 		<![CDATA[
 using System;
 using System.IO;
@@ -694,7 +694,7 @@ namespace $(pkgname)
 }
 ]]>
 	</Template>
-	<Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19">
+	<Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
 		<![CDATA[
 using System;
 using System.IO;

--- a/Aras.VS.MethodPlugin.11sp8CSharp/method-config.xml
+++ b/Aras.VS.MethodPlugin.11sp8CSharp/method-config.xml
@@ -599,7 +599,7 @@ End Namespace
 ]]>
 		</Template>
 
-		<Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19">
+		<Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
 				<![CDATA[
 using System;
 using System.IO;
@@ -693,7 +693,7 @@ namespace $(pkgname)
 }
 ]]>
 		</Template>
-		<Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19">
+		<Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
 				<![CDATA[
 using System;
 using System.IO;

--- a/Aras.VS.MethodPlugin.11sp9CSharp/method-config.xml
+++ b/Aras.VS.MethodPlugin.11sp9CSharp/method-config.xml
@@ -599,7 +599,7 @@ End Namespace
 ]]>
   </Template>
 
-  <Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19">
+  <Template name="ConflictDetectionLocalRuleCSharp.version:1" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
     <![CDATA[
 using System;
 using System.IO;
@@ -693,7 +693,7 @@ namespace $(pkgname)
 }
 ]]>
   </Template>
-  <Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19">
+  <Template name="CSharp:Aras.TDF.ContentGenerator(Extended)" line_number_offset="19" isSupported="False" message="Current template is not successfully supported.">
     <![CDATA[
 using System;
 using System.IO;


### PR DESCRIPTION
Added 'isSupported' and 'message' attributes in method
config templates to indicate not successfully supported
templates